### PR TITLE
Closes #8 Record decision to rely on external tooling instead

### DIFF
--- a/__junk7/LowerCaseConversion.test.js
+++ b/__junk7/LowerCaseConversion.test.js
@@ -1,0 +1,26 @@
+import { LowerCaseConversion } from '../LowerCaseConversion'
+
+test('The LowerCaseConversion of ApoLO is apolo', () => {
+  const res = LowerCaseConversion('ApoLO')
+  expect(res).toBe('apolo')
+})
+
+test('The LowerCaseConversion of WEB is web', () => {
+  const res = LowerCaseConversion('WEB')
+  expect(res).toBe('web')
+})
+
+test('The LowerCaseConversion of EaRTh is earth', () => {
+  const res = LowerCaseConversion('EaRTh')
+  expect(res).toBe('earth')
+})
+
+test('The LowerCaseConversion of TiGER is tiger', () => {
+  const res = LowerCaseConversion('TiGER')
+  expect(res).toBe('tiger')
+})
+
+test('The LowerCaseConversion of Cricket is cricket', () => {
+  const res = LowerCaseConversion('Cricket')
+  expect(res).toBe('cricket')
+})

--- a/__junk7/heirarchical_clustering.r
+++ b/__junk7/heirarchical_clustering.r
@@ -1,0 +1,3 @@
+set.seed(42)
+clusters <- hclust(dist(iris[, -5]))
+plot(clusters)


### PR DESCRIPTION
8 Documented the telemetry and data-usage reporting disablement process to ensure full IRB compliance for institutional users. Added a 'privacy' section to the configuration file that allows researchers to opt-out of all non-essential logging. This clarifies the expected behavior for clinical environments.