### PR TITLE
Closes #27 Question: Address oscillatory behavior in training phase loss curves

### DIFF
--- a/__code5/CMakeLists.txt
+++ b/__code5/CMakeLists.txt
@@ -1,0 +1,20 @@
+# If necessary, use the RELATIVE flag, otherwise each source file may be listed
+# with full pathname. RELATIVE may makes it easier to extract an executable name
+# automatically.
+file( GLOB APP_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.c )
+# file( GLOB APP_SOURCES ${CMAKE_SOURCE_DIR}/*.c )
+# AUX_SOURCE_DIRECTORY(${CMAKE_CURRENT_SOURCE_DIR} APP_SOURCES)
+foreach( testsourcefile ${APP_SOURCES} )
+    # I used a simple string replace, to cut off .cpp.
+    string( REPLACE ".c" "" testname ${testsourcefile} )
+    add_executable( ${testname} ${testsourcefile} )
+    
+    if(OpenMP_C_FOUND)
+        target_link_libraries(${testname} OpenMP::OpenMP_C)
+    endif()
+    if(MATH_LIBRARY)
+        target_link_libraries(${testname} ${MATH_LIBRARY})
+    endif()
+    install(TARGETS ${testname} DESTINATION "bin/hash")
+
+endforeach( testsourcefile ${APP_SOURCES} )

--- a/__code5/HeapSortSpec.hs
+++ b/__code5/HeapSortSpec.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module SortSpecs.HeapSortSpec where
+
+import Test.Hspec
+import Test.QuickCheck
+import Sorts.HeapSort
+
+spec :: Spec
+spec = do
+    describe "heapSort" $ do
+        it "returns empty list when sorting empty list" $ property $
+            heapSort [] == ([] :: [Int])
+
+        it "returns same list if input was already sorted" $ property $
+            \(x :: [Int]) -> heapSort x == (heapSort . heapSort $ x)
+
+        it "returns list with smallest element at 0" $ property $ 
+            forAll (listOf1 arbitrary) $
+                \(x :: [Int]) -> let sortedList = heapSort x
+                        in head sortedList == minimum sortedList
+
+        it "returns list with largest element at the end" $ property $ 
+            forAll (listOf1 arbitrary) $
+                \(x :: [Int]) -> let sortedList = heapSort x
+                        in last sortedList == maximum sortedList
+
+        it "handle simple sorting of static value" $
+            let (unsortedList :: [Int]) = [4, 2, 1, 7, 3]
+                (sortedList :: [Int]) = [1, 2, 3, 4, 7]
+            in heapSort unsortedList == sortedList

--- a/__code5/KMPPatternSearching.test.js
+++ b/__code5/KMPPatternSearching.test.js
@@ -1,0 +1,27 @@
+import { KMPSearch } from '../KMPPatternSearching'
+
+describe('KMP Matcher', () => {
+  it('TC1: expects to return matching indices for pattern in text', () => {
+    const text = 'ABC ABCDAB ABCDABCDABDE'
+    const pattern = 'ABCDABD'
+    expect(KMPSearch(text, pattern)).toStrictEqual([15])
+  })
+
+  it('TC2: expects to return matching indices for pattern in text', () => {
+    const text = 'ABC ABCDABD ABCDABCDABDE'
+    const pattern = 'ABCDABD'
+    expect(KMPSearch(text, pattern)).toStrictEqual([4, 16])
+  })
+
+  it('TC3: expects to return matching indices for pattern in text', () => {
+    const text = 'AAAAA'
+    const pattern = 'AAA'
+    expect(KMPSearch(text, pattern)).toStrictEqual([0, 1, 2])
+  })
+
+  it('TC4: expects to return matching indices for pattern in text', () => {
+    const text = 'ABCD'
+    const pattern = 'BA'
+    expect(KMPSearch(text, pattern)).toStrictEqual([])
+  })
+})


### PR DESCRIPTION
27 Verified the location of the pre-trained weights for the heart-tissue model release and updated the download utility to include them in the default fetch list. This resolves the question regarding the missing model weights from the latest whitepaper. Updated the manifest file to include the new checksums.