### PR TITLE
Closes #66 Implement model bias detection for clinical predictions

### DIFF
--- a/__temp4/Chebyshev.cs
+++ b/__temp4/Chebyshev.cs
@@ -1,0 +1,28 @@
+namespace Algorithms.LinearAlgebra.Distances;
+
+/// <summary>
+/// Implementation of Chebyshev distance.
+/// It is the maximum absolute difference between the measures in all dimensions of two points.
+/// In other words, it is the maximum distance one has to travel along any coordinate axis to get from one point to another.
+///
+/// It is commonly used in various fields such as chess, warehouse logistics, and more.
+/// </summary>
+public static class Chebyshev
+{
+    /// <summary>
+    /// Calculate Chebyshev distance for two N-Dimensional points.
+    /// </summary>
+    /// <param name="point1">First N-Dimensional point.</param>
+    /// <param name="point2">Second N-Dimensional point.</param>
+    /// <returns>Calculated Chebyshev distance.</returns>
+    public static double Distance(double[] point1, double[] point2)
+    {
+        if (point1.Length != point2.Length)
+        {
+            throw new ArgumentException("Both points should have the same dimensionality");
+        }
+
+        // distance = max(|x1-y1|, |x2-y2|, ..., |xn-yn|)
+        return point1.Zip(point2, (x1, x2) => Math.Abs(x1 - x2)).Max();
+    }
+}

--- a/__temp4/ElasticCollision2DTest.java
+++ b/__temp4/ElasticCollision2DTest.java
@@ -1,0 +1,91 @@
+package com.thealgorithms.physics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ElasticCollision2DTest {
+
+    @Test
+    void testEqualMassHeadOnCollision() {
+        ElasticCollision2D.Body a = new ElasticCollision2D.Body(0, 0, 1, 0, 1.0, 0.5);
+        ElasticCollision2D.Body b = new ElasticCollision2D.Body(1, 0, -1, 0, 1.0, 0.5);
+
+        ElasticCollision2D.resolveCollision(a, b);
+
+        assertEquals(-1.0, a.vx, 1e-6);
+        assertEquals(0.0, a.vy, 1e-6);
+        assertEquals(1.0, b.vx, 1e-6);
+        assertEquals(0.0, b.vy, 1e-6);
+    }
+
+    @Test
+    void testUnequalMassHeadOnCollision() {
+        ElasticCollision2D.Body a = new ElasticCollision2D.Body(0, 0, 2, 0, 2.0, 0.5);
+        ElasticCollision2D.Body b = new ElasticCollision2D.Body(1, 0, -1, 0, 1.0, 0.5);
+
+        ElasticCollision2D.resolveCollision(a, b);
+
+        // 1D head-on collision results
+        assertEquals(0.0, a.vx, 1e-6);
+        assertEquals(0.0, a.vy, 1e-6);
+        assertEquals(3.0, b.vx, 1e-6);
+        assertEquals(0.0, b.vy, 1e-6);
+    }
+
+    @Test
+    void testMovingApartNoCollision() {
+        ElasticCollision2D.Body a = new ElasticCollision2D.Body(0, 0, -1, 0, 1.0, 0.5);
+        ElasticCollision2D.Body b = new ElasticCollision2D.Body(1, 0, 1, 0, 1.0, 0.5);
+
+        ElasticCollision2D.resolveCollision(a, b);
+
+        assertEquals(-1.0, a.vx, 1e-6);
+        assertEquals(0.0, a.vy, 1e-6);
+        assertEquals(1.0, b.vx, 1e-6);
+        assertEquals(0.0, b.vy, 1e-6);
+    }
+
+    @Test
+    void testGlancingCollision() {
+        ElasticCollision2D.Body a = new ElasticCollision2D.Body(0, 0, 1, 1, 1.0, 0.5);
+        ElasticCollision2D.Body b = new ElasticCollision2D.Body(1, 1, -1, -0.5, 1.0, 0.5);
+
+        ElasticCollision2D.resolveCollision(a, b);
+
+        // Ensure relative velocity along normal is reversed
+        double nx = (b.x - a.x) / Math.hypot(b.x - a.x, b.y - a.y);
+        double ny = (b.y - a.y) / Math.hypot(b.x - a.x, b.y - a.y);
+        double relVelAfter = (b.vx - a.vx) * nx + (b.vy - a.vy) * ny;
+
+        assertTrue(relVelAfter > 0);
+    }
+
+    @Test
+    void testOverlappingBodies() {
+        ElasticCollision2D.Body a = new ElasticCollision2D.Body(0, 0, 1, 0, 1.0, 0.5);
+        ElasticCollision2D.Body b = new ElasticCollision2D.Body(0, 0, -1, 0, 1.0, 0.5);
+
+        ElasticCollision2D.resolveCollision(a, b);
+
+        // Should not crash, velocities may remain unchanged
+        assertEquals(1.0, a.vx, 1e-6);
+        assertEquals(0.0, a.vy, 1e-6);
+        assertEquals(-1.0, b.vx, 1e-6);
+        assertEquals(0.0, b.vy, 1e-6);
+    }
+
+    @Test
+    void testStationaryBodyHit() {
+        ElasticCollision2D.Body a = new ElasticCollision2D.Body(0, 0, 2, 0, 1.0, 0.5);
+        ElasticCollision2D.Body b = new ElasticCollision2D.Body(1, 0, 0, 0, 1.0, 0.5);
+
+        ElasticCollision2D.resolveCollision(a, b);
+
+        assertEquals(0.0, a.vx, 1e-6);
+        assertEquals(0.0, a.vy, 1e-6);
+        assertEquals(2.0, b.vx, 1e-6);
+        assertEquals(0.0, b.vy, 1e-6);
+    }
+}

--- a/__temp4/FindMin.java
+++ b/__temp4/FindMin.java
@@ -1,0 +1,26 @@
+package com.thealgorithms.maths;
+
+public final class FindMin {
+    private FindMin() {
+    }
+
+    /**
+     * @brief finds the minimum value stored in the input array
+     *
+     * @param array the input array
+     * @exception IllegalArgumentException input array is empty
+     * @return the mimum value stored in the input array
+     */
+    public static int findMin(final int[] array) {
+        if (array.length == 0) {
+            throw new IllegalArgumentException("Array must be non-empty.");
+        }
+        int min = array[0];
+        for (int i = 1; i < array.length; i++) {
+            if (array[i] < min) {
+                min = array[i];
+            }
+        }
+        return min;
+    }
+}

--- a/__temp4/MinimumPathSumTest.java
+++ b/__temp4/MinimumPathSumTest.java
@@ -1,0 +1,50 @@
+package com.thealgorithms.dynamicprogramming;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class MinimumPathSumTest {
+
+    @Test
+    public void testMinimumPathSumWithRegularGrid() {
+        int[][] grid = {{1, 3, 1}, {1, 5, 1}, {4, 2, 1}};
+        assertEquals(7, MinimumPathSum.minimumPathSum(grid));
+    }
+
+    @Test
+    public void testMinimumPathSumWithOneRowOneColumnGrid() {
+        int[][] grid = {{2}};
+        assertEquals(2, MinimumPathSum.minimumPathSum(grid));
+    }
+
+    @Test
+    public void testMinimumPathSumWithEmptyGrid() {
+        int[][] grid = {{}};
+        assertEquals(0, MinimumPathSum.minimumPathSum(grid));
+    }
+
+    @Test
+    public void testMinimumPathSumWithOneColumnGrid() {
+        int[][] grid = {{1}, {2}, {3}};
+        assertEquals(6, MinimumPathSum.minimumPathSum(grid));
+    }
+
+    @Test
+    public void testMinimumPathSumGridOneRowGrid() {
+        int[][] grid = {{1, 2, 3}};
+        assertEquals(6, MinimumPathSum.minimumPathSum(grid));
+    }
+
+    @Test
+    public void testMinimumPathSumWithDiffRowAndColumnGrid() {
+        int[][] grid = {{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}};
+        assertEquals(30, MinimumPathSum.minimumPathSum(grid));
+    }
+
+    @Test
+    public void testMinimumPathSumWithNegativeNumberGrid() {
+        int[][] grid = {{1, 3, 1}, {3, 4, 1}, {4, -3, 1}};
+        assertEquals(6, MinimumPathSum.minimumPathSum(grid));
+    }
+}

--- a/__temp4/sqrt_test.go
+++ b/__temp4/sqrt_test.go
@@ -1,0 +1,50 @@
+// sqrt_test.go
+// description: Test for square root calculation
+// author(s) [red_byte](https://github.com/i-redbyte)
+// see sqrt.go
+
+package binary
+
+import (
+	"math"
+	"testing"
+)
+
+const epsilon = 0.001
+
+func TestSquareRootCalculation(t *testing.T) {
+	tests := []struct {
+		name   string
+		number float32
+		want   float64
+	}{
+		{"sqrt(1)", 1, 1},
+		{"sqrt(9)", 9, 3},
+		{"sqrt(25)", 25, 5},
+		{"sqrt(121)", 121, 11},
+		{"sqrt(10000)", 10000, 100},
+		{"sqrt(169)", 169, 13},
+		{"sqrt(0)", 0, 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := Sqrt(test.number)
+			delta := math.Abs(test.want - float64(got))
+			if delta > epsilon {
+				t.Errorf("Sqrt() = %v, want %v delta %v", got, test.want, delta)
+			}
+		})
+	}
+}
+
+func BenchmarkSquareRootCalculation(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Sqrt(225)
+	}
+}
+
+func BenchmarkMathSqrt(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		math.Sqrt(225)
+	}
+}


### PR DESCRIPTION
66 Updated the normalization method configuration in the scRNA-seq YAML to clarify the use of LogNormalize vs. SCtransform. This change ensures that users can easily toggle between different statistical approaches without modifying the core logic. Added a comment section explaining the math behind each.